### PR TITLE
BEL-158108: add optional args: conclusion and status

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -13,11 +13,17 @@ inputs:
   token:
     description: 'token to use for API requests'
     required: true
+  conclusion:
+    description: 'conclusion: action_required, cancelled, failure, neutral, success, skipped, stale, or timed_out'
+    default: ""
+  status:
+    description: 'status: queued, in_progress, or completed'
+    default: ""
 outputs:
   running-jobs-count:
     description: "The number of workflow jobs that are running on the specified branch."
   last-build-sha:
-    description: "The commit SHA of the most recent build of this workflow on the specified branch."
+    description: "The commit SHA of the most recent build of this workflow on the specified branch optionally filtered by status and conclusion"
   workflow-id:
     description: "The id of the specifed workflow."
 runs:
@@ -32,3 +38,7 @@ runs:
     - ${{ inputs.repository }}
     - '--token'
     - ${{ inputs.token }}
+    - '--conclusion'
+    - ${{ inputs.conclusion }}
+    - '--status'
+    - ${{ inputs.status }}

--- a/entrypoint.rb
+++ b/entrypoint.rb
@@ -9,6 +9,10 @@ OptionParser.new do |opt|
   opt.on('--branch BRANCH') { |o| options[:branch] = o }
   opt.on('--repository REPOSITORY') { |o| options[:repository] = o }
   opt.on('--token TOKEN') { |o| options[:token] = o }
+  options[:conclusion] = ""
+  opt.on('--conclusion CONCLUSION') { |o| options[:conclusion] = o }
+  options[:status] = ""
+  opt.on('--status STATUS') { |o| options[:status] = o }
 end.parse!
 
 client = Octokit::Client.new(:access_token => options[:token])
@@ -17,6 +21,8 @@ client.auto_paginate = true
 response = client.repository_workflow_runs(options[:repository], {:branch => options[:branch]})
 
 workflow_runs = response[:workflow_runs].select { |run| run[:name] == options[:name] }
+workflow_runs = workflow_runs.select { |run| run[:conclusion] == options[:conclusion] } if !options[:conclusion].empty?
+workflow_runs = workflow_runs.select { |run| run[:status] == options[:status] } if !options[:status].empty?
 
 last_build_sha_run = workflow_runs.max_by { |run| run[:run_number] }
 last_build_sha = last_build_sha_run[:head_sha]


### PR DESCRIPTION
- `conclusion` to be able to check for lsb (with `success`)
- `status` for when actions-workflow-info is called in a workflow referring to itself (in order to check for last built SHA need to use `complete`)

Tested:
https://github.com/onshape/test-actions/actions/runs/621594311