### PR TITLE
Use workflow_runs() for better performance and to workaround auto_paginate not working

### DIFF
--- a/entrypoint.rb
+++ b/entrypoint.rb
@@ -18,9 +18,7 @@ end.parse!
 client = Octokit::Client.new(:access_token => options[:token])
 client.auto_paginate = true
 
-response = client.repository_workflow_runs(options[:repository], {:branch => options[:branch]})
-
-workflow_runs = response[:workflow_runs].select { |run| run[:name] == options[:name] }
+workflow_runs = client.workflow_runs(options[:repository], "#{options[:name]}.yml", {:branch => options[:branch]})[:workflow_runs]
 workflow_runs = workflow_runs.select { |run| run[:conclusion] == options[:conclusion] } if !options[:conclusion].empty?
 workflow_runs = workflow_runs.select { |run| run[:status] == options[:status] } if !options[:status].empty?
 


### PR DESCRIPTION
Use workflow_runs() so branch filtering is done REST/server-side which improves performance by a few seconds and 100 results should be more than enough in this context.

Tested:
- manually on several repos/workflows and android/veracode

More detail:
The android/veracode run [failed](https://github.com/onshape/android/runs/3140179917?check_suite_focus=true) on 7/24 because the action couldn't determine lsb/master after 8 failed runs, this was because repository_workflow_runs() gets 100 results across all android repo workflows and that wasn't enough history (auto_paginate seems to have [issues](https://stackoverflow.com/questions/53845488/how-to-fetch-all-the-deployed-commits-from-octokit-github-client-for-ruby))

